### PR TITLE
Change title to always use the word "arbeit" instead of thesis

### DIFF
--- a/styles/titlepage.typ
+++ b/styles/titlepage.typ
@@ -39,14 +39,13 @@
 
   context {
     let lang = text.lang
+    align(left, text(weight: "bold", degree + "arbeit"))
     if lang == "de" {
       align(left, text(16pt, strong(title-german), fill: dark-color))
       align(left, text(16pt, title-english, fill: dark-color))
-      align(left, text(weight: "bold", degree + "arbeit"))
     } else {
       align(left, text(16pt, strong(title-english), fill: dark-color))
       align(left, text(16pt, title-german, fill: dark-color))
-      align(left, text(weight: "bold", degree + "’s Thesis"))
     }
 
   }


### PR DESCRIPTION
The official guideline of the MINT Prüfungsausschüsse requires that the term “Bachelorarbeit” (Bachelor thesis) always be used. The term “Bachelor's thesis,” on the other hand, is not permitted. This PR adjusts the code accordingly and removes the English wording.

For more information see https://www.uni-luebeck.de/fileadmin/uzl_ssc/PDF-Dateien/Richtlinie-Deckblatt-MINT-Abschlussarbeit-2012-10-18.pdf